### PR TITLE
Add protocol attributes to endpoints definition.

### DIFF
--- a/etc/che-plugin.yaml
+++ b/etc/che-plugin.yaml
@@ -2,6 +2,8 @@ endpoints:
  -  name: "theia-dev-flow"
     public: true
     targetPort: 3010
+    attributes:
+      protocol: http
 containers:
  - name: theia-dev
    image: eclipse/che-theia-dev:nightly


### PR DESCRIPTION
Add protocol attributes to endpoints definition. It's useful for user dashboard server link. Dashboard without this attributes unable to detect server protocol and write tcp instead of http.