### PR TITLE
Increase memory to use for che-dev container

### DIFF
--- a/etc/che-plugin.yaml
+++ b/etc/che-plugin.yaml
@@ -16,5 +16,5 @@ containers:
        name: projects
    ports:
      - exposedPort: 3010
-   memory-limit: "1536M"
-   memoryLimit: "1536M"
+   memory-limit: "2Gi"
+   memoryLimit: "2Gi"


### PR DESCRIPTION
Wasn't enough to run yarn on theia (process killed)